### PR TITLE
Fix Bug: Passthrough Sourcemaps

### DIFF
--- a/src/remove-attributes.ts
+++ b/src/remove-attributes.ts
@@ -9,6 +9,7 @@ import type {
     Options
 } from "./types";
 import type { Plugin } from "vite"
+import type { SourceDescription } from 'rollup'
 
 export default function removeAttributesPlugin(options: Options): Plugin {
     const optionList: Options = getOptions(options);
@@ -17,18 +18,19 @@ export default function removeAttributesPlugin(options: Options): Plugin {
     return {
         name: 'remove-attributes',
         enforce: 'pre',
-        transform(code: string, id: string): string {
+        transform(code: string, id: string): Partial<SourceDescription> {
+            const map = null
             if (hasIgnorePath(id)) {
-                return code;
+                return {code, map };
             }
             if (hasIgnorePath(id, ignoredPaths)) {
-                return code;
+                return {code, map};
             }
             if (!hasExtension(id, optionList)) {
-                return code;
+                return {code, map};
             }
 
-            return removeAttributes(code, optionList.attributes)
+            return {code: removeAttributes(code, optionList.attributes), map}
         },
     };
 }


### PR DESCRIPTION
Closes issue #1.

Prior to this change, building with Vite using this plugin yielded the warning message:

> "(remove-attributes plugin) Sourcemap is likely to be incorrect:
>  a plugin (remove-attributes) was used to transform files, but didn't
>  generate a sourcemap for the transformation.
>  Consult the plugin documentation for help"

The sourcemaps of all files, even JS files which weren't affected by the plugin looked like this:

```js
{
    "version":3,
    "file":"myFile.js",
    "sources":[],
    "sourcesContent":[],
    "names":[],
    "mappings":";;;;;;;;;;;;;;"
}
```

Comments in the issue pointed out [how the same issue was fixed elsewhere](https://github.com/mustafadalga/remove-attr/issues/1#issuecomment-2149136679), and another one [shared a solution](https://github.com/mustafadalga/remove-attr/issues/1#issuecomment-2219757231).

This commit incorporates these comments into the repository.